### PR TITLE
feat(next): Optimize the space information display

### DIFF
--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import {
+  p_14_medium,
   p_14_normal,
   p_16_semibold,
   p_20_semibold,
@@ -7,6 +8,10 @@ import {
 import SpaceLogo from "@/components/spaceLogo";
 import ChainIcon from "./chain/chainIcon";
 import ValueDisplay from "./valueDisplay";
+import Modal from "./modal";
+import { useState } from "react";
+import Divider from "./styled/divider";
+import { capitalize, toPrecision } from "frontedUtils";
 
 const Wrapper = styled.div`
   display: flex;
@@ -95,7 +100,62 @@ const ChainIcons = styled.div`
   }
 `;
 
+const ModalLogoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  // override 'SpaceLogo' margin-right
+  > :first-child {
+    margin-right: 0;
+  }
+`;
+
+const ModalLogoName = styled(LogoName)`
+  margin-top: 16px;
+`;
+
+const ModalAboutWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const ModalAboutTitle = styled.div`
+  ${p_16_semibold};
+`;
+
+const ModalInfoWrapper = styled.div``;
+
+const ModalInfoItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 16px;
+`;
+
+const ModalInfoName = styled.div``;
+
+const ModalInfoValue = styled.div`
+  ${p_14_medium};
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: 4px;
+`;
+
+const ModalInfoNetwork = styled.span`
+  margin-right: 8px;
+`;
+
 export default function ListInfo({ space }) {
+  const [modalVisible, setModalVisible] = useState(false);
+
+  const strategyCount = space.weightStrategy?.length || 0;
+  const networkCount = space.networks?.length || 0;
+
+  const handleShowModal = () => {
+    setModalVisible(true);
+  };
+
   return (
     <Wrapper>
       <LogoWrapper>
@@ -109,7 +169,7 @@ export default function ListInfo({ space }) {
         <AboutItem>
           <AboutIcon src="/imgs/icons/threshold.svg" />
           <div>
-            <AboutName>Threshold</AboutName>
+            <AboutName onClick={handleShowModal}>Threshold</AboutName>
             <AboutDetail>
               <ValueDisplay
                 value={space.proposeThreshold}
@@ -122,7 +182,7 @@ export default function ListInfo({ space }) {
         <AboutItem>
           <AboutIcon src="/imgs/icons/strategy.svg" />
           <div>
-            <AboutName>Strategy({space.weightStrategy?.length || 0})</AboutName>
+            <AboutName>Strategy({strategyCount})</AboutName>
             <StrategyAboutDetail>
               {space.weightStrategy?.[0]}
               {space.weightStrategy?.length > 1 && ", ..."}
@@ -133,7 +193,7 @@ export default function ListInfo({ space }) {
         <AboutItem>
           <AboutIcon src="/imgs/icons/network.svg" />
           <div>
-            <AboutName>Network({space.networks?.length || 0})</AboutName>
+            <AboutName>Network({networkCount})</AboutName>
             <ChainIconsWrapper>
               <ChainIcons>
                 {space.networks?.slice(0, 3).map((network, index) => (
@@ -144,6 +204,54 @@ export default function ListInfo({ space }) {
             </ChainIconsWrapper>
           </div>
         </AboutItem>
+
+        <Modal open={modalVisible} setOpen={setModalVisible}>
+          <ModalLogoWrapper>
+            <SpaceLogo spaceId={space.id} />
+            <ModalLogoName>{space.name}</ModalLogoName>
+            <LogoSymbol>{space.symbol}</LogoSymbol>
+          </ModalLogoWrapper>
+
+          <ModalAboutWrapper>
+            <ModalAboutTitle>About</ModalAboutTitle>
+            <img src="/imgs/icons/info.svg" />
+          </ModalAboutWrapper>
+
+          <Divider />
+
+          <ModalInfoWrapper>
+            <ModalInfoItem>
+              <ModalInfoName>Threshold</ModalInfoName>
+              <ModalInfoValue>
+                {toPrecision(space.proposeThreshold, space.decimals)}{" "}
+                {space.symbol}
+              </ModalInfoValue>
+            </ModalInfoItem>
+
+            <ModalInfoItem>
+              <ModalInfoName>Strategies({strategyCount})</ModalInfoName>
+              <div>
+                {space.weightStrategy?.map((strategy, index) => (
+                  <ModalInfoValue key={index}>{strategy}</ModalInfoValue>
+                ))}
+              </div>
+            </ModalInfoItem>
+
+            <ModalInfoItem>
+              <ModalInfoName>Networks({networkCount})</ModalInfoName>
+              <div>
+                {space.networks?.map((network, index) => (
+                  <ModalInfoValue key={index}>
+                    <ModalInfoNetwork>
+                      {capitalize(network.network)}
+                    </ModalInfoNetwork>{" "}
+                    <ChainIcon chainName={network.network} />
+                  </ModalInfoValue>
+                ))}
+              </div>
+            </ModalInfoItem>
+          </ModalInfoWrapper>
+        </Modal>
       </AboutWrapper>
     </Wrapper>
   );

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -101,26 +101,6 @@ export default function ListInfo({ space }) {
       </LogoWrapper>
       <AboutWrapper>
         <AboutItem>
-          <AboutIcon src="/imgs/icons/network.svg" />
-          <div>
-            <AboutName>Networks({space.networks?.length || 0})</AboutName>
-            <ChainIcons>
-              {space.networks?.map((network, index) => (
-                <ChainIcon key={index} chainName={network.network} />
-              ))}
-            </ChainIcons>
-          </div>
-          <Tooltip
-            content={space.networks
-              ?.map((item) => capitalize(item.network))
-              .join(", ")}
-            size="full"
-          >
-            <div />
-          </Tooltip>
-        </AboutItem>
-        <AboutDivider />
-        <AboutItem>
           <AboutIcon src="/imgs/icons/threshold.svg" />
           <div>
             <AboutName>Threshold</AboutName>
@@ -152,6 +132,26 @@ export default function ListInfo({ space }) {
             </StrategyAboutDetail>
           </div>
           <Tooltip content={space.weightStrategy?.join(", ")} size="full">
+            <div />
+          </Tooltip>
+        </AboutItem>
+        <AboutDivider />
+        <AboutItem>
+          <AboutIcon src="/imgs/icons/network.svg" />
+          <div>
+            <AboutName>Networks({space.networks?.length || 0})</AboutName>
+            <ChainIcons>
+              {space.networks?.map((network, index) => (
+                <ChainIcon key={index} chainName={network.network} />
+              ))}
+            </ChainIcons>
+          </div>
+          <Tooltip
+            content={space.networks
+              ?.map((item) => capitalize(item.network))
+              .join(", ")}
+            size="full"
+          >
             <div />
           </Tooltip>
         </AboutItem>

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -52,6 +52,11 @@ const AboutIcon = styled.img`
 const AboutName = styled.div`
   ${p_16_semibold};
   margin-bottom: 2px;
+  cursor: pointer;
+
+  :hover {
+    text-decoration: underline;
+  }
 `;
 
 const AboutDetail = styled.div`

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -67,10 +67,7 @@ const StrategyAboutDetail = styled.div`
   font-size: 14px;
   line-height: 24px;
   color: #a1a8b3;
-  text-overflow: ellipsis;
   max-width: 240px;
-  overflow: hidden;
-  white-space: nowrap;
 `;
 
 const AboutDivider = styled.div`

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { toPrecision } from "frontedUtils";
 import {
   p_14_normal,
   p_16_semibold,
@@ -7,6 +6,7 @@ import {
 } from "../styles/textStyles";
 import SpaceLogo from "@/components/spaceLogo";
 import ChainIcon from "./chain/chainIcon";
+import ValueDisplay from "./valueDisplay";
 
 const Wrapper = styled.div`
   display: flex;
@@ -110,10 +110,12 @@ export default function ListInfo({ space }) {
           <AboutIcon src="/imgs/icons/threshold.svg" />
           <div>
             <AboutName>Threshold</AboutName>
-            <AboutDetail>{`${toPrecision(
-              space.proposeThreshold,
-              space.decimals
-            )} ${space.symbol}`}</AboutDetail>
+            <AboutDetail>
+              <ValueDisplay
+                value={space.proposeThreshold}
+                space={space}
+              ></ValueDisplay>
+            </AboutDetail>
           </div>
         </AboutItem>
         <AboutDivider />

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -120,9 +120,7 @@ export default function ListInfo({ space }) {
         <AboutItem>
           <AboutIcon src="/imgs/icons/strategy.svg" />
           <div>
-            <AboutName>
-              Strategies({space.weightStrategy?.length || 0})
-            </AboutName>
+            <AboutName>Strategy({space.weightStrategy?.length || 0})</AboutName>
             <StrategyAboutDetail>
               {space.weightStrategy?.[0]}
               {space.weightStrategy?.length > 1 && ", ..."}

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -77,6 +77,12 @@ const AboutDivider = styled.div`
   margin: 0 40px;
 `;
 
+const ChainIconsWrapper = styled.div`
+  font-size: 14px;
+  line-height: 24px;
+  color: #a1a8b3;
+`;
+
 const ChainIcons = styled.div`
   display: flex;
   svg,
@@ -134,12 +140,15 @@ export default function ListInfo({ space }) {
         <AboutItem>
           <AboutIcon src="/imgs/icons/network.svg" />
           <div>
-            <AboutName>Networks({space.networks?.length || 0})</AboutName>
-            <ChainIcons>
-              {space.networks?.map((network, index) => (
-                <ChainIcon key={index} chainName={network.network} />
-              ))}
-            </ChainIcons>
+            <AboutName>Network({space.networks?.length || 0})</AboutName>
+            <ChainIconsWrapper>
+              <ChainIcons>
+                {space.networks?.slice(0, 3).map((network, index) => (
+                  <ChainIcon key={index} chainName={network.network} />
+                ))}
+                {space.networks?.length > 3 && "..."}
+              </ChainIcons>
+            </ChainIconsWrapper>
           </div>
           <Tooltip
             content={space.networks

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -89,6 +89,7 @@ const ChainIconsWrapper = styled.div`
   font-size: 14px;
   line-height: 24px;
   color: #a1a8b3;
+  display: flex;
 `;
 
 const ChainIcons = styled.div`
@@ -203,8 +204,8 @@ export default function ListInfo({ space }) {
                 {space.networks?.slice(0, 3).map((network, index) => (
                   <ChainIcon key={index} chainName={network.network} />
                 ))}
-                {space.networks?.length > 3 && "..."}
               </ChainIcons>
+              {space.networks?.length > 3 && "..."}
             </ChainIconsWrapper>
           </div>
         </AboutItem>

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -6,9 +6,7 @@ import {
   p_20_semibold,
 } from "../styles/textStyles";
 import SpaceLogo from "@/components/spaceLogo";
-import Tooltip from "@/components/tooltip";
 import ChainIcon from "./chain/chainIcon";
-import { capitalize } from "frontedUtils";
 
 const Wrapper = styled.div`
   display: flex;
@@ -112,15 +110,6 @@ export default function ListInfo({ space }) {
               space.decimals
             )} ${space.symbol}`}</AboutDetail>
           </div>
-          <Tooltip
-            content={`At least ${toPrecision(
-              space.proposeThreshold,
-              space.decimals
-            )}${space.symbol} to create a proposal`}
-            size="full"
-          >
-            <div />
-          </Tooltip>
         </AboutItem>
         <AboutDivider />
         <AboutItem>
@@ -132,9 +121,6 @@ export default function ListInfo({ space }) {
               {space.weightStrategy?.length > 1 && ", ..."}
             </StrategyAboutDetail>
           </div>
-          <Tooltip content={space.weightStrategy?.join(", ")} size="full">
-            <div />
-          </Tooltip>
         </AboutItem>
         <AboutDivider />
         <AboutItem>
@@ -150,14 +136,6 @@ export default function ListInfo({ space }) {
               </ChainIcons>
             </ChainIconsWrapper>
           </div>
-          <Tooltip
-            content={space.networks
-              ?.map((item) => capitalize(item.network))
-              .join(", ")}
-            size="full"
-          >
-            <div />
-          </Tooltip>
         </AboutItem>
       </AboutWrapper>
     </Wrapper>

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -147,13 +147,13 @@ const ModalInfoNetwork = styled.span`
 `;
 
 export default function ListInfo({ space }) {
-  const [modalVisible, setModalVisible] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
 
   const strategyCount = space.weightStrategy?.length || 0;
   const networkCount = space.networks?.length || 0;
 
   const handleShowModal = () => {
-    setModalVisible(true);
+    setModalOpen(true);
   };
 
   return (
@@ -209,7 +209,7 @@ export default function ListInfo({ space }) {
           </div>
         </AboutItem>
 
-        <Modal open={modalVisible} setOpen={setModalVisible}>
+        <Modal open={modalOpen} setOpen={setModalOpen}>
           <ModalLogoWrapper>
             <SpaceLogo spaceId={space.id} />
             <ModalLogoName>{space.name}</ModalLogoName>

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -103,7 +103,7 @@ export default function ListInfo({ space }) {
         <AboutItem>
           <AboutIcon src="/imgs/icons/network.svg" />
           <div>
-            <AboutName>Networks</AboutName>
+            <AboutName>Networks({space.networks?.length || 0})</AboutName>
             <ChainIcons>
               {space.networks?.map((network, index) => (
                 <ChainIcon key={index} chainName={network.network} />
@@ -147,7 +147,8 @@ export default function ListInfo({ space }) {
               Strategies({space.weightStrategy?.length || 0})
             </AboutName>
             <StrategyAboutDetail>
-              {space.weightStrategy?.join(", ")}
+              {space.weightStrategy?.[0]}
+              {space.weightStrategy?.length > 1 && ", ..."}
             </StrategyAboutDetail>
           </div>
           <Tooltip content={space.weightStrategy?.join(", ")} size="full">

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -182,7 +182,9 @@ export default function ListInfo({ space }) {
         <AboutItem>
           <AboutIcon src="/imgs/icons/strategy.svg" />
           <div>
-            <AboutName>Strategy({strategyCount})</AboutName>
+            <AboutName onClick={handleShowModal}>
+              Strategy({strategyCount})
+            </AboutName>
             <StrategyAboutDetail>
               {space.weightStrategy?.[0]}
               {space.weightStrategy?.length > 1 && ", ..."}
@@ -193,7 +195,9 @@ export default function ListInfo({ space }) {
         <AboutItem>
           <AboutIcon src="/imgs/icons/network.svg" />
           <div>
-            <AboutName>Network({networkCount})</AboutName>
+            <AboutName onClick={handleShowModal}>
+              Network({networkCount})
+            </AboutName>
             <ChainIconsWrapper>
               <ChainIcons>
                 {space.networks?.slice(0, 3).map((network, index) => (

--- a/packages/next/components/listInfo.js
+++ b/packages/next/components/listInfo.js
@@ -12,6 +12,7 @@ import Modal from "./modal";
 import { useState } from "react";
 import Divider from "./styled/divider";
 import { capitalize, toPrecision } from "frontedUtils";
+import Button from "./button";
 
 const Wrapper = styled.div`
   display: flex;
@@ -147,6 +148,15 @@ const ModalInfoNetwork = styled.span`
   margin-right: 8px;
 `;
 
+const ModalInfoActions = styled.div`
+  margin-top: 20px;
+  text-align: right;
+`;
+
+const ModalInfoCloseButton = styled(Button)`
+  display: inline-block;
+`;
+
 export default function ListInfo({ space }) {
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -256,6 +266,12 @@ export default function ListInfo({ space }) {
               </div>
             </ModalInfoItem>
           </ModalInfoWrapper>
+
+          <ModalInfoActions>
+            <ModalInfoCloseButton onClick={() => setModalOpen(false)}>
+              Close
+            </ModalInfoCloseButton>
+          </ModalInfoActions>
         </Modal>
       </AboutWrapper>
     </Wrapper>

--- a/packages/next/components/listInfo/details.js
+++ b/packages/next/components/listInfo/details.js
@@ -61,7 +61,6 @@ const DetailsValue = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  margin-bottom: 4px;
 `;
 
 const DetailsNetwork = styled.span`
@@ -110,7 +109,7 @@ export default function Details({ space }) {
             {space.networks?.map((network, index) => (
               <DetailsValue key={index}>
                 <DetailsNetwork>{capitalize(network.network)}</DetailsNetwork>{" "}
-                <ChainIcon chainName={network.network} />
+                <ChainIcon chainName={network.network} size={20} />
               </DetailsValue>
             ))}
           </div>

--- a/packages/next/components/listInfo/details.js
+++ b/packages/next/components/listInfo/details.js
@@ -1,0 +1,115 @@
+import styled from "styled-components";
+import {
+  p_14_normal,
+  p_14_medium,
+  p_16_semibold,
+  p_20_semibold,
+} from "../../styles/textStyles";
+import SpaceLogo from "@/components/spaceLogo";
+import ChainIcon from "../chain/chainIcon";
+import Button from "../button";
+import Divider from "../styled/divider";
+import { capitalize, toPrecision } from "frontedUtils";
+
+const Wrapper = styled.div``;
+
+const LogoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  // override 'SpaceLogo' margin-right
+  > :first-child {
+    margin-right: 0;
+  }
+`;
+
+const LogoName = styled.div`
+  ${p_20_semibold};
+  margin-top: 16px;
+  text-transform: capitalize;
+`;
+
+const LogoSymbol = styled.div`
+  ${p_14_normal};
+  color: #a1a8b3;
+`;
+
+const DetailsWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const DetailsTitle = styled.div`
+  ${p_16_semibold};
+`;
+
+const DetailsItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 16px;
+`;
+
+const DetailsValue = styled.div`
+  ${p_14_medium};
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: 4px;
+`;
+
+const DetailsNetwork = styled.span`
+  margin-right: 8px;
+`;
+
+export default function Details({ space }) {
+  const strategyCount = space.weightStrategy?.length || 0;
+  const networkCount = space.networks?.length || 0;
+
+  return (
+    <Wrapper>
+      <LogoWrapper>
+        <SpaceLogo spaceId={space.id} />
+        <LogoName>{space.name}</LogoName>
+        <LogoSymbol>{space.symbol}</LogoSymbol>
+      </LogoWrapper>
+
+      <DetailsWrapper>
+        <DetailsTitle>About</DetailsTitle>
+        <img src="/imgs/icons/info.svg" />
+      </DetailsWrapper>
+
+      <Divider />
+
+      <div>
+        <DetailsItem>
+          <div>Threshold</div>
+          <DetailsValue>
+            {toPrecision(space.proposeThreshold, space.decimals)} {space.symbol}
+          </DetailsValue>
+        </DetailsItem>
+
+        <DetailsItem>
+          <div>Strategies({strategyCount})</div>
+          <div>
+            {space.weightStrategy?.map((strategy, index) => (
+              <DetailsValue key={index}>{strategy}</DetailsValue>
+            ))}
+          </div>
+        </DetailsItem>
+
+        <DetailsItem>
+          <div>Networks({networkCount})</div>
+          <div>
+            {space.networks?.map((network, index) => (
+              <DetailsValue key={index}>
+                <DetailsNetwork>{capitalize(network.network)}</DetailsNetwork>{" "}
+                <ChainIcon chainName={network.network} />
+              </DetailsValue>
+            ))}
+          </div>
+        </DetailsItem>
+      </div>
+    </Wrapper>
+  );
+}

--- a/packages/next/components/listInfo/details.js
+++ b/packages/next/components/listInfo/details.js
@@ -51,6 +51,11 @@ const DetailsItem = styled.div`
   line-height: 24px;
 `;
 
+const DetailsLabel = styled.span`
+  ${p_14_medium};
+  color: #506176;
+`;
+
 const DetailsValue = styled.div`
   ${p_14_medium};
   display: flex;
@@ -84,14 +89,14 @@ export default function Details({ space }) {
 
       <div>
         <DetailsItem>
-          <span>Threshold</span>
+          <DetailsLabel>Threshold</DetailsLabel>
           <DetailsValue>
             {toPrecision(space.proposeThreshold, space.decimals)} {space.symbol}
           </DetailsValue>
         </DetailsItem>
 
         <DetailsItem>
-          <span>Strategies({strategyCount})</span>
+          <DetailsLabel>Strategies({strategyCount})</DetailsLabel>
           <div>
             {space.weightStrategy?.map((strategy, index) => (
               <DetailsValue key={index}>{strategy}</DetailsValue>
@@ -100,7 +105,7 @@ export default function Details({ space }) {
         </DetailsItem>
 
         <DetailsItem>
-          <span>Networks({networkCount})</span>
+          <DetailsLabel>Networks({networkCount})</DetailsLabel>
           <div>
             {space.networks?.map((network, index) => (
               <DetailsValue key={index}>

--- a/packages/next/components/listInfo/details.js
+++ b/packages/next/components/listInfo/details.js
@@ -7,7 +7,6 @@ import {
 } from "../../styles/textStyles";
 import SpaceLogo from "@/components/spaceLogo";
 import ChainIcon from "../chain/chainIcon";
-import Button from "../button";
 import Divider from "../styled/divider";
 import { capitalize, toPrecision } from "frontedUtils";
 

--- a/packages/next/components/listInfo/details.js
+++ b/packages/next/components/listInfo/details.js
@@ -50,6 +50,10 @@ const DetailsItem = styled.div`
   margin-bottom: 16px;
 `;
 
+const DetailsLabel = styled.span`
+  line-height: 24px;
+`;
+
 const DetailsValue = styled.div`
   ${p_14_medium};
   display: flex;
@@ -83,14 +87,14 @@ export default function Details({ space }) {
 
       <div>
         <DetailsItem>
-          <div>Threshold</div>
+          <DetailsLabel>Threshold</DetailsLabel>
           <DetailsValue>
             {toPrecision(space.proposeThreshold, space.decimals)} {space.symbol}
           </DetailsValue>
         </DetailsItem>
 
         <DetailsItem>
-          <div>Strategies({strategyCount})</div>
+          <DetailsLabel>Strategies({strategyCount})</DetailsLabel>
           <div>
             {space.weightStrategy?.map((strategy, index) => (
               <DetailsValue key={index}>{strategy}</DetailsValue>
@@ -99,7 +103,7 @@ export default function Details({ space }) {
         </DetailsItem>
 
         <DetailsItem>
-          <div>Networks({networkCount})</div>
+          <DetailsLabel>Networks({networkCount})</DetailsLabel>
           <div>
             {space.networks?.map((network, index) => (
               <DetailsValue key={index}>

--- a/packages/next/components/listInfo/details.js
+++ b/packages/next/components/listInfo/details.js
@@ -8,7 +8,8 @@ import {
 import SpaceLogo from "@/components/spaceLogo";
 import ChainIcon from "../chain/chainIcon";
 import Divider from "../styled/divider";
-import { abbreviateBigNumber, capitalize, toPrecision } from "frontedUtils";
+import { capitalize } from "frontedUtils";
+import ValueDisplay from "../valueDisplay";
 
 const Wrapper = styled.div``;
 
@@ -90,10 +91,7 @@ export default function Details({ space }) {
         <DetailsItem>
           <DetailsLabel>Threshold</DetailsLabel>
           <DetailsValue>
-            {abbreviateBigNumber(
-              toPrecision(space.proposeThreshold, space?.decimals)
-            )}{" "}
-            {space.symbol}
+            <ValueDisplay value={space.proposeThreshold} space={space} />
           </DetailsValue>
         </DetailsItem>
 

--- a/packages/next/components/listInfo/details.js
+++ b/packages/next/components/listInfo/details.js
@@ -48,9 +48,6 @@ const DetailsItem = styled.div`
   display: flex;
   justify-content: space-between;
   margin-bottom: 16px;
-`;
-
-const DetailsLabel = styled.span`
   line-height: 24px;
 `;
 
@@ -87,14 +84,14 @@ export default function Details({ space }) {
 
       <div>
         <DetailsItem>
-          <DetailsLabel>Threshold</DetailsLabel>
+          <span>Threshold</span>
           <DetailsValue>
             {toPrecision(space.proposeThreshold, space.decimals)} {space.symbol}
           </DetailsValue>
         </DetailsItem>
 
         <DetailsItem>
-          <DetailsLabel>Strategies({strategyCount})</DetailsLabel>
+          <span>Strategies({strategyCount})</span>
           <div>
             {space.weightStrategy?.map((strategy, index) => (
               <DetailsValue key={index}>{strategy}</DetailsValue>
@@ -103,7 +100,7 @@ export default function Details({ space }) {
         </DetailsItem>
 
         <DetailsItem>
-          <DetailsLabel>Networks({networkCount})</DetailsLabel>
+          <span>Networks({networkCount})</span>
           <div>
             {space.networks?.map((network, index) => (
               <DetailsValue key={index}>

--- a/packages/next/components/listInfo/details.js
+++ b/packages/next/components/listInfo/details.js
@@ -8,7 +8,7 @@ import {
 import SpaceLogo from "@/components/spaceLogo";
 import ChainIcon from "../chain/chainIcon";
 import Divider from "../styled/divider";
-import { capitalize, toPrecision } from "frontedUtils";
+import { abbreviateBigNumber, capitalize, toPrecision } from "frontedUtils";
 
 const Wrapper = styled.div``;
 
@@ -90,7 +90,10 @@ export default function Details({ space }) {
         <DetailsItem>
           <DetailsLabel>Threshold</DetailsLabel>
           <DetailsValue>
-            {toPrecision(space.proposeThreshold, space.decimals)} {space.symbol}
+            {abbreviateBigNumber(
+              toPrecision(space.proposeThreshold, space?.decimals)
+            )}{" "}
+            {space.symbol}
           </DetailsValue>
         </DetailsItem>
 

--- a/packages/next/components/listInfo/details.js
+++ b/packages/next/components/listInfo/details.js
@@ -27,6 +27,7 @@ const LogoName = styled.div`
   ${p_20_semibold};
   margin-top: 16px;
   text-transform: capitalize;
+  line-height: 28px;
 `;
 
 const LogoSymbol = styled.div`

--- a/packages/next/components/listInfo/index.js
+++ b/packages/next/components/listInfo/index.js
@@ -70,7 +70,7 @@ const AboutDetail = styled.div`
   text-transform: capitalize;
 `;
 
-const StrategyAboutDetail = styled.div`
+const StrategyAboutDetail = styled.span`
   font-size: 14px;
   line-height: 24px;
   color: #a1a8b3;
@@ -145,7 +145,7 @@ export default function ListInfo({ space }) {
             <AboutName onClick={handleShowModal}>
               Strategy({strategyCount})
             </AboutName>
-            <StrategyAboutDetail>
+            <StrategyAboutDetail title={space.weightStrategy?.join(", ")}>
               {space.weightStrategy?.[0]}
               {space.weightStrategy?.length > 1 && ", ..."}
             </StrategyAboutDetail>

--- a/packages/next/components/listInfo/index.js
+++ b/packages/next/components/listInfo/index.js
@@ -134,10 +134,7 @@ export default function ListInfo({ space }) {
           <div>
             <AboutName onClick={handleShowModal}>Threshold</AboutName>
             <AboutDetail>
-              <ValueDisplay
-                value={space.proposeThreshold}
-                space={space}
-              ></ValueDisplay>
+              <ValueDisplay value={space.proposeThreshold} space={space} />
             </AboutDetail>
           </div>
         </AboutItem>

--- a/packages/next/components/listInfo/index.js
+++ b/packages/next/components/listInfo/index.js
@@ -1,18 +1,16 @@
 import styled from "styled-components";
 import {
-  p_14_medium,
   p_14_normal,
   p_16_semibold,
   p_20_semibold,
-} from "../styles/textStyles";
+} from "../../styles/textStyles";
 import SpaceLogo from "@/components/spaceLogo";
-import ChainIcon from "./chain/chainIcon";
-import ValueDisplay from "./valueDisplay";
-import Modal from "./modal";
+import ChainIcon from "../chain/chainIcon";
+import ValueDisplay from "../valueDisplay";
+import Modal from "../modal";
 import { useState } from "react";
-import Divider from "./styled/divider";
-import { capitalize, toPrecision } from "frontedUtils";
-import Button from "./button";
+import Details from "./details";
+import Button from "../button";
 
 const Wrapper = styled.div`
   display: flex;
@@ -102,58 +100,12 @@ const ChainIcons = styled.div`
   }
 `;
 
-const ModalLogoWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-
-  // override 'SpaceLogo' margin-right
-  > :first-child {
-    margin-right: 0;
-  }
-`;
-
-const ModalLogoName = styled(LogoName)`
-  margin-top: 16px;
-`;
-
-const ModalAboutWrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
-`;
-
-const ModalAboutTitle = styled.div`
-  ${p_16_semibold};
-`;
-
-const ModalInfoWrapper = styled.div``;
-
-const ModalInfoItem = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 16px;
-`;
-
-const ModalInfoName = styled.div``;
-
-const ModalInfoValue = styled.div`
-  ${p_14_medium};
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  margin-bottom: 4px;
-`;
-
-const ModalInfoNetwork = styled.span`
-  margin-right: 8px;
-`;
-
-const ModalInfoActions = styled.div`
+const ModalActions = styled.div`
   margin-top: 20px;
   text-align: right;
 `;
 
-const ModalInfoCloseButton = styled(Button)`
+const ModalCloseButton = styled(Button)`
   display: inline-block;
 `;
 
@@ -221,57 +173,13 @@ export default function ListInfo({ space }) {
         </AboutItem>
 
         <Modal open={modalOpen} setOpen={setModalOpen}>
-          <ModalLogoWrapper>
-            <SpaceLogo spaceId={space.id} />
-            <ModalLogoName>{space.name}</ModalLogoName>
-            <LogoSymbol>{space.symbol}</LogoSymbol>
-          </ModalLogoWrapper>
+          <Details space={space} />
 
-          <ModalAboutWrapper>
-            <ModalAboutTitle>About</ModalAboutTitle>
-            <img src="/imgs/icons/info.svg" />
-          </ModalAboutWrapper>
-
-          <Divider />
-
-          <ModalInfoWrapper>
-            <ModalInfoItem>
-              <ModalInfoName>Threshold</ModalInfoName>
-              <ModalInfoValue>
-                {toPrecision(space.proposeThreshold, space.decimals)}{" "}
-                {space.symbol}
-              </ModalInfoValue>
-            </ModalInfoItem>
-
-            <ModalInfoItem>
-              <ModalInfoName>Strategies({strategyCount})</ModalInfoName>
-              <div>
-                {space.weightStrategy?.map((strategy, index) => (
-                  <ModalInfoValue key={index}>{strategy}</ModalInfoValue>
-                ))}
-              </div>
-            </ModalInfoItem>
-
-            <ModalInfoItem>
-              <ModalInfoName>Networks({networkCount})</ModalInfoName>
-              <div>
-                {space.networks?.map((network, index) => (
-                  <ModalInfoValue key={index}>
-                    <ModalInfoNetwork>
-                      {capitalize(network.network)}
-                    </ModalInfoNetwork>{" "}
-                    <ChainIcon chainName={network.network} />
-                  </ModalInfoValue>
-                ))}
-              </div>
-            </ModalInfoItem>
-          </ModalInfoWrapper>
-
-          <ModalInfoActions>
-            <ModalInfoCloseButton onClick={() => setModalOpen(false)}>
+          <ModalActions>
+            <ModalCloseButton onClick={() => setModalOpen(false)}>
               Close
-            </ModalInfoCloseButton>
-          </ModalInfoActions>
+            </ModalCloseButton>
+          </ModalActions>
         </Modal>
       </AboutWrapper>
     </Wrapper>

--- a/packages/next/components/modal.js
+++ b/packages/next/components/modal.js
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+import { Modal as SemanticModal } from "semantic-ui-react";
+
+const Wrapper = styled.div``;
+
+const StyledModal = styled(SemanticModal)`
+  max-width: 400px !important;
+  border-radius: 0 !important;
+`;
+
+const StyledCard = styled.div`
+  margin: 0 !important;
+  padding: 24px !important;
+  position: relative !important;
+  width: 100% !important;
+`;
+
+const CloseBar = styled.div`
+  display: flex;
+  flex-direction: row-reverse;
+
+  > svg path {
+    fill: #9da9bb;
+  }
+
+  cursor: pointer;
+`;
+
+export default function Modal({ open, setOpen, children }) {
+  const closeModal = () => setOpen(false);
+
+  const closeButton = (
+    <img onClick={closeModal} src="/imgs/icons/close.svg" width={24} alt="" />
+  );
+
+  return (
+    <Wrapper>
+      <StyledModal open={open} onClose={closeModal} dimmer size="tiny">
+        <StyledCard>
+          <CloseBar>{closeButton}</CloseBar>
+
+          {children}
+        </StyledCard>
+      </StyledModal>
+    </Wrapper>
+  );
+}


### PR DESCRIPTION
close #656 

- [x] [Display the number](https://www.figma.com/file/vqpglMGW8psHKB00eIVDUV/OpenSquare?node-id=8478%3A39372) of strategy and network
- [x] If threshold amount is a large number, [use abbreviations](https://www.figma.com/file/vqpglMGW8psHKB00eIVDUV/OpenSquare?node-id=8511%3A47417)
- [x] Display a maximum of one entry in strategy, replace the excess entries with an ellipsis
- [x] Display a maximum of three icons in network, replace the excess icons with an ellipsis
- [x] [When hover over the title](https://www.figma.com/file/vqpglMGW8psHKB00eIVDUV/OpenSquare?node-id=8478%3A50767)(threshold, strategy, network), add underline. (remove tooltip effect)
- [x] [Click the title](https://www.figma.com/file/vqpglMGW8psHKB00eIVDUV/OpenSquare?node-id=8478%3A50767) to display the details popup