### PR TITLE
fix(next): typo

### DIFF
--- a/packages/next/components/datePicker.js
+++ b/packages/next/components/datePicker.js
@@ -5,7 +5,7 @@ import "react-datepicker/dist/react-datepicker.css";
 import moment from "moment";
 
 import { useOnClickOutside } from "frontedUtils/hooks";
-import { ReactCopmonent as CaretRight } from "/public/imgs/icons/caret-right.svg";
+import { ReactComponent as CaretRight } from "/public/imgs/icons/caret-right.svg";
 import { ReactComponent as ArrowLeft } from "/public/imgs/icons/arrow-left.svg";
 import { ReactComponent as ArrowRight } from "/public/imgs/icons/arrow-right.svg";
 import Button from "@osn/common-ui/dist/styled/Button";


### PR DESCRIPTION
revert part of 690

no build warnings
![image](https://user-images.githubusercontent.com/19513289/164181348-eda1899c-8e68-49e6-b18d-038707803abd.png)

no more typos of `ReactComponent`
![image](https://user-images.githubusercontent.com/19513289/164181305-533bb781-eafd-4930-aff1-29c2c096427f.png)
