### PR TITLE
HOTTIX improper text ellipsis, #756

### DIFF
--- a/packages/next/components/identityOrAddr.js
+++ b/packages/next/components/identityOrAddr.js
@@ -13,11 +13,12 @@ const IdentityWrapper = styled.span`
   ${(p) =>
           p.ellipsis &&
           css`
-            max-width: calc(100% - 10px);
+            > span:first-child {
+              height: 24px;
+            }
             > span:last-child {
-              white-space: nowrap;
-              text-overflow: ellipsis;
-              overflow: hidden;
+              position: absolute;
+              left: 14px;
             }
     `}
 `;


### PR DESCRIPTION
# before 
<img width="752" alt="image" src="https://user-images.githubusercontent.com/12393771/167056680-e950527b-020e-47cc-b86c-6a2ac2475616.png">

# after
<img width="762" alt="image" src="https://user-images.githubusercontent.com/12393771/167056655-e6a84bc9-0439-44c2-ae77-23c680ec4b12.png">
