### PR TITLE
HOTFIX: remvoe redundant width strict css, #762

### DIFF
--- a/packages/next/components/postDetail/biasedVotingItem.js
+++ b/packages/next/components/postDetail/biasedVotingItem.js
@@ -13,7 +13,7 @@ const LabelWrapper = styled.div`
   color: #506176;
   position: relative;
   display: flex;
-
+  max-width: 55%;
   // for tooltip with size=fit
   > *:first-child {
     max-width: 100%;

--- a/packages/next/components/postDetail/biasedVotingItem.js
+++ b/packages/next/components/postDetail/biasedVotingItem.js
@@ -13,7 +13,6 @@ const LabelWrapper = styled.div`
   color: #506176;
   position: relative;
   display: flex;
-  width: 60%;
 
   // for tooltip with size=fit
   > *:first-child {
@@ -31,7 +30,6 @@ const Label = styled.span`
 const ValueDisplayWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
-  width: 40%;
 `;
 
 function BiasedVotingItem({ label, value, space }) {


### PR DESCRIPTION
# before
<img width="312" alt="image" src="https://user-images.githubusercontent.com/12393771/167233565-168ab5c0-b492-4f21-9ec4-7c8d74e54ac7.png">


# after 
<img width="288" alt="image" src="https://user-images.githubusercontent.com/12393771/167241842-cc18d89e-8db6-4bfd-a0f5-f4f6b7a072c1.png">
