### PR TITLE
fix: improve code block visibility in light mode (#1125)

### DIFF
--- a/next/components/editor/index.js
+++ b/next/components/editor/index.js
@@ -1,17 +1,34 @@
 import { cn } from "@osn/common-ui";
 import dynamic from "next/dynamic";
 import { useState } from "react";
+import styled from "styled-components";
 import LoadingEditor from "./loading";
+import { code_block_pre, code_inline, code_pre_reset } from "../styles/editorStyles";
 
 const RichEditor = dynamic(
   () => import("@osn/common-ui").then((mod) => mod.RichEditor),
   { ssr: false, loading: () => <LoadingEditor /> },
 );
 
+
+const EditorContainer = styled.div`  
+  .rich-editor pre {
+    ${code_block_pre}
+  }
+
+  .rich-editor code:not(pre code) {
+    ${code_inline}
+  }
+
+  .rich-editor pre code {
+    ${code_pre_reset}
+  }
+`;
+
 export default function Editor(props) {
   const [isPreview, setIsPreview] = useState(false);
   return (
-    <div
+    <EditorContainer
       className={cn(
         "relative",
         isPreview
@@ -21,6 +38,6 @@ export default function Editor(props) {
       )}
     >
       <RichEditor {...props} onChangePreviewMode={setIsPreview} />
-    </div>
+    </EditorContainer>
   );
 }

--- a/next/components/editor/loading.js
+++ b/next/components/editor/loading.js
@@ -1,25 +1,9 @@
 import { cn, useIsDark } from "@osn/common-ui";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
+import { skeleton_gradient_dark, skeleton_gradient_light } from "../styles/editorStyles";
 
 const SkeletonDiv = styled.div`
-  ${(props) =>
-    props.isDark
-      ? css`
-          background: linear-gradient(
-            90deg,
-            var(--fillBgTertiary) 0%,
-            var(--neutralGray900) 49.5%,
-            var(--fillBgTertiary) 100%
-          );
-        `
-      : css`
-          background: linear-gradient(
-            270deg,
-            var(--fillBgTertiary) 0%,
-            var(--neutralGray50) 50%,
-            var(--fillBgTertiary) 100%
-          );
-        `}
+  ${(props) => props.isDark ? skeleton_gradient_dark : skeleton_gradient_light}
 `;
 
 const Skeleton = (props) => {
@@ -36,16 +20,16 @@ export default function LoadingEditor() {
         "border-t border-b border-strokeActionDisable",
       )}
     >
-      <div className="flex py-[12px] gap-[20px] sm:hidden">
-        <Skeleton className="h-[24px] grow" />
-        <Skeleton className="h-[24px] grow" />
+      <div className="flex py-[12px] gap-[20px] sm:hidden px-4">
+        <Skeleton className="h-[24px] grow rounded" />
+        <Skeleton className="h-[24px] grow rounded" />
       </div>
-      <div className="flex justify-between py-[12px] border-t border-strokeActionDisable">
+      <div className="flex justify-between py-[12px] px-4 border-t border-strokeActionDisable">
         <div className="flex gap-[20px] max-sm:hidden">
-          <Skeleton className="h-[24px] w-[80px]" />
-          <Skeleton className="h-[24px] w-[80px]" />
+          <Skeleton className="h-[24px] w-[80px] rounded" />
+          <Skeleton className="h-[24px] w-[80px] rounded" />
         </div>
-        <Skeleton className="h-[24px] grow sm:max-w-[240px]" />
+        <Skeleton className="h-[24px] grow sm:max-w-[240px] rounded" />
       </div>
       <div className="grow bg-fillBgInputDefault"></div>
     </div>

--- a/next/styles/editorStyles.js
+++ b/next/styles/editorStyles.js
@@ -1,0 +1,68 @@
+import { css } from "styled-components";
+
+export const code_block_base = css`
+  background-color: var(--fillBgSecondary) !important;
+  color: var(--textPrimary) !important;
+  border: 1px solid var(--strokeBorderDefault) !important;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', monospace !important;
+`;
+
+export const code_block_pre = css`
+  ${code_block_base}
+  border-radius: 8px !important;
+  padding: 16px !important;
+  margin: 16px 0 !important;
+  overflow-x: auto !important;
+  font-size: 0.875em !important;
+  line-height: 1.5 !important;
+`;
+
+export const code_inline = css`
+  ${code_block_base}
+  border-radius: 4px !important;
+  padding: 2px 6px !important;
+  font-size: 0.875em !important;
+  vertical-align: baseline !important;
+`;
+
+export const code_pre_reset = css`
+  background: none !important;
+  border: none !important;
+  padding: 0 !important;
+  color: inherit !important;
+`;
+
+
+export const skeleton_animation = css`
+  background-size: 200% 100%;
+  animation: skeleton-loading 2s infinite ease-in-out;
+
+  @keyframes skeleton-loading {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
+`;
+
+export const skeleton_gradient_dark = css`
+  background: linear-gradient(
+    90deg,
+    var(--fillBgTertiary) 0%,
+    var(--neutralGray900) 49.5%,
+    var(--fillBgTertiary) 100%
+  );
+  ${skeleton_animation}
+`;
+
+export const skeleton_gradient_light = css`
+  background: linear-gradient(
+    270deg,
+    var(--fillBgTertiary) 0%,
+    var(--neutralGray50) 50%,
+    var(--fillBgTertiary) 100%
+  );
+  ${skeleton_animation}
+`;


### PR DESCRIPTION
close  #1125

## Problem
Code blocks in the rich editor were difficult to read in light mode due to poor contrast and missing visual boundaries.

##  Changes Made
- Added `editorStyles.js` with reusable style constants
- Updated `Editor` component with styled-components container
- Enhanced `LoadingEditor` with improved skeleton animations
- Applied consistent theming using existing CSS variables

##   Technical Details
- Uses `var(--fillBgSecondary)` and `var(--strokeBorderDefault)` for consistency
- Maintains responsive design with proper mobile styles
- Follows project's styled-components patterns
- No breaking changes to existing functionality
